### PR TITLE
Feat: 이메일 로그인, 로그아웃 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,21 +5,31 @@ const dotenv = require('dotenv');
 const nunjucks = require('nunjucks');
 const session = require('express-session');
 const cookieParser = require('cookie-parser');
-// const passport = requitr('passport');
+const passport = require('passport');
+const cors = require('cors'); 
 
 dotenv.config();
 
 const pageRouter = require('./routes/page');
 const postRouter = require('./routes/post');
 const authRouter = require('./routes/auth');
+const passportConfig = require('./passport'); 
 
 const app = express();
+passportConfig(); // passport 실행
 app.set('port', process.env.PORT || 8001);
 app.set('view engine', 'html');
 nunjucks.configure('views', {
     express: app,
     watch: true,  // +chokidar 
 });
+
+// const corsOption = {
+//     origin: 'http://localhost:3000',
+//     credentials: true, 
+//     method: ['GET', 'POST', 'PUT', 'DELETE'],
+// };
+// app.use(cors(corsOption));
 
 app.use(morgan('dev')); 
 app.use(express.static(path.join(__dirname, 'public'))); 
@@ -28,13 +38,28 @@ app.use(express.urlencoded({extended: true}));
 app.use(cookieParser(process.env.COOKIE_SECRET));
 app.use(session({
     resave: false,
-    saveUnintialized: false,
+    saveUninitialized: false,
     secret: process.env.COOKIE_SECRET,
     cookie: {
         httpOnly: true,
         secure: false, 
+        // maxAge: 1000 * 60 * 60 * 2  // 2시간 유지 
     }
 }));
+app.use((req, res, next) => {
+    console.log('현재 세션이 유지되는지:', req.session);
+    next(); 
+});
+
+app.use(passport.initialize()); 
+app.use(passport.session()); 
+app.use((req, res, next) => {
+    console.log('현재 세션:', req.session); 
+    console.log('현재 세션에 passport 있는지 확인', req.session.passport); 
+    console.log('현재 로그인 된 사용자:', req.user);
+    res.locals.user = req.user || null; // 모든 템플릿에서 user 사용 가능  
+    next(); 
+});
 
 app.use('/', pageRouter); 
 app.use('/post', postRouter);

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,11 +1,13 @@
+const passport = require('passport');
 const db = require('../db');
 const bcrypt = require('bcrypt');
+const { authPlugins } = require('mysql2');
 
 exports.join = async (req, res, next) => {
     try {
         console.log(`req.body: ${req.body}`);
         if (!req.body) {
-            return res.status(400).send("req.body가 없습니다!");
+            return res.status(400).send("회원가입: req.body가 없습니다!");
         }
         const { nickname, password, email} = req.body;
         // 모든 필드가 입력됐됐다는 상황에서 
@@ -13,9 +15,78 @@ exports.join = async (req, res, next) => {
         const sql = `INSERT INTO users (nickname, password, email) VALUES (?, ?, ?)`;
         const [results] = await db.query(sql, [nickname, hash, email]);
         console.log(`회원가입에 성공했습니다. SQL 실행결과 results: ${JSON.stringify(results)}`);
-        
+        return res.status(200).json({ message: "회원가입 성공"});
     } catch (error) {
         console.error(error);
         next(error);
     }
 };
+
+
+// passport.authenticate / req.login, Promise 기반으로 래핑(try-catch)
+exports.login = async (req, res, next) => {
+    try {
+        // passport.authenticate를 프로미스로 래핑하여 사용자 인증
+        const user = await new Promise((resolve, reject) => {
+            passport.authenticate('local', (authError, user, info) => {
+                if (authError) return reject(authError);
+                if (!user) return reject(new Error(info.message || '로그인 실패'));
+                resolve(user);
+            })(req, res, next);
+        });
+        
+        // req.login + 세션 저장을 프로미스로 래핑(세션 저장 없이도 가능)
+        await new Promise((resolve, reject) => {
+            req.login(user, (error) => { // 세션에 저장할 사용자 객체 user 
+                if (error) return reject(error);
+                req.session.save((error) => {  // 세션 저장
+                    if (error) return reject(error);
+                    resolve();  // 반환X (undefined) 
+                });
+                // resolve();  // 세션 저장 없이도 가능 
+            });
+        });
+        console.log('로그인 성공:', user);
+        // 세션이 저장된 후 리다이렉트
+        res.redirect('/');
+    } catch (error) {
+        console.error('로그인 에러:', error);
+        next(error);
+    }
+    
+};
+
+
+//// req.user 생성 불가 오류 - 세션 저장 작업을 비동기로 처리 전, 리다이렉트나 응답 전송이 이루어져 다음 요청에서 req.user=undifined. 다음 요청에서 변경 사항이 반영X
+// exports.login = (req, res, next) => {
+//     passport.authenticate('local', (authError, user, info) => { // done 호출
+//         // 서버 실패
+//         if (authError) {
+//             console.error(authError);
+//             return next(authError);
+//         }
+//         // 로직 실패
+//         if (!user) {
+//             // return res.redirect(`/?loginError=${info.message}`);
+//             return res.redirect('/user/login?error=' + encodeURIComponent(info.message || '로그인 실패'));
+//         }
+//         // 로그인 성공 +로그인 과정 중 에러 처리
+//         req.login(user, (loginError) => {
+            
+//             if (loginError) {
+//                 console.error(loginError);
+//                 return next(loginError);
+//             }
+//         })
+//         // return res.json({ success: true, user});
+//         console.log(`로그인 성공: ${user}`); 
+//         return res.redirect('/');
+//     })(req, res, next);
+// };
+
+exports.logout = (req, res, next) => {
+    req.logout(() => {
+        console.log('로그아웃 성공');
+        res.redirect('/');
+    });
+}

--- a/middlwares/index.js
+++ b/middlwares/index.js
@@ -1,0 +1,19 @@
+// 로그인 했을 때
+exports.isLoggedIn = (req, res, next) => {
+    // Passport 제공 메서드 사용해 로그인 체크
+    if (req.isAuthenticated()) {
+        next();
+    } else {
+        res.status(403).send('로그인 필요');
+    }
+};
+
+// 로그인 안 했을 때
+exports.isNotLoggedIn = (req, res, next) => {
+    if (!req.isAuthenticated()) {
+        next();
+    } else {
+        const message = encodeURIComponent('로그인 한 상태입니다.');
+        res.redirect(`/?error=${message}`);  
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "bcrypt": "^5.1.1",
         "chokidar": "^3.6.0",
         "cookie-parser": "^1.4.7",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "express-session": "^1.18.1",
@@ -19,7 +20,8 @@
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.12.0",
         "nunjucks": "^3.2.4",
-        "passport": "^0.7.0"
+        "passport": "^0.7.0",
+        "passport-local": "^1.0.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.9"
@@ -497,6 +499,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1685,6 +1700,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/passport-strategy": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "node_express_practice",
   "version": "0.0.1",
   "description": "practice node express",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
+    "start": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -20,6 +21,7 @@
     "bcrypt": "^5.1.1",
     "chokidar": "^3.6.0",
     "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
@@ -27,7 +29,8 @@
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.12.0",
     "nunjucks": "^3.2.4",
-    "passport": "^0.7.0"
+    "passport": "^0.7.0",
+    "passport-local": "^1.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/passport/index.js
+++ b/passport/index.js
@@ -1,0 +1,33 @@
+const passport = require('passport');
+const local = require('./localStrategy');
+const db = require('../db');
+
+module.exports = () => {
+    passport.serializeUser((user, done) => {
+        console.log('사용자 아이디만 저장하는 serializeUser:', user.id);
+        done(null, user.id);
+    });
+
+    passport.deserializeUser(async (id, done) => {
+        try {
+            console.log('사용자 찾아 req.user에 넣어주는 deserializeUser:', id);
+            const sql = `SELECT * FROM users WHERE id = ?`;
+            const [results] = await db.query(sql, [id]);
+
+            // 찾는 유저가 없다면
+            if (!results.length) {
+                console.log('쿼리 실행 X, 사용자 없음:');
+                return done(null, false); 
+            }
+            const user = results[0];
+            console.log(`find user sql: ${JSON.stringify(user)}`);  
+            return done(null, user); // 성공하면 req.user에 저장
+        } catch (error) {
+            console.error('deserializeUser 에러!:', error); 
+            done(error); 
+        }
+    });
+    local();
+}; // 여기서 exports 되는 함수가 app.js의 passportConfig() 
+
+

--- a/passport/localStrategy.js
+++ b/passport/localStrategy.js
@@ -1,0 +1,33 @@
+const passport = require('passport');
+const bcrypt = require('bcrypt');
+const { Strategy: LocalStrategy } = require('passport-local');
+const db = require('../db'); 
+
+// 이메일 로그인 함수 
+module.exports = () => { 
+    passport.use(new LocalStrategy({ 
+        usernameField: 'email', // req.body.email => usernameField
+        passwordField: 'password', // req.body.password => passwordField
+        passReqToCallback: false,
+    }, async (email, password, done) => { 
+        try {
+            const sql = `SELECT * From users WHERE email = ?`; // 
+            const [results] = await db.query(sql, [email]);
+            console.log(`find user 실행 결과: ${JSON.stringify(results)})`);
+            const exUser = results[0]; // 쿼리 결과는 배열 형태로 반환. 첫 사용자의 객체
+            if (exUser) { 
+            // 사용자가 입력한 패스워드가 디비에 저장된 패스워드와 일치하는지
+                const result = await bcrypt.compare(password, exUser.password);
+                if (result) {
+                    done(null, exUser); // 성공
+                } else {
+                    done(null, false, { message: '비밀번호가 일치하지 않습니다.' });
+                }
+            } else {
+                done(null, false, { message: '가입되지 않은 회원입니다.' });            }
+        } catch (error) {
+            console.error(error);
+            done(error); // 인증 도중 발생한 예상치 못한 에러를 Passport에 알림 
+        }
+    }
+))};

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,7 +1,25 @@
 const express = require('express');
 const router = express.Router();
-const { join } = require('../controllers/auth');
+const { join, login, logout } = require('../controllers/auth');
+const { isLoggedIn, isNotLoggedIn } = require('../middlwares');
 
-router.post('/join', join); // controllers/join 컨트롤러 호출(서버 연결)
+// 회원가입 GET
+router.get('/join', isNotLoggedIn, (req, res) => {
+    res.render('join');
+});
+
+// 회원가입 POST 
+router.post('/join', isNotLoggedIn, join); // controllers/join 컨트롤러 호출(서버 연결)
+
+// 로그인 GET
+router.get('/login', isNotLoggedIn, (req, res) => {
+    res.render('login'); 
+});
+
+// 로그인 POST
+router.post('/login', isNotLoggedIn, login);
+
+// 로그아웃 POST
+router.post('/logout', isLoggedIn, logout);
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,8 +1,0 @@
-const express = require('express');
-const router = express.Router();
-
-router.get('/', (req, res) => {
-    res.send('홈페이지');
-});
-
-module.exports = router; 

--- a/routes/page.js
+++ b/routes/page.js
@@ -1,9 +1,14 @@
 const express = require('express');
 const router = express.Router();
 const { renderMain, renderJoin } = require('../controllers/page');
+const { isNotLoggedIn } = require('../middlwares');
 
+// router.use((req, res, next) => {
+//     res.locals.user = req.user; // passport 과정 이후
+//     next(); 
+// });
 
 router.get('/', renderMain); // 메인 화면 
-router.get('/join', renderJoin); // 라우터에서 컨트롤러 호출
+router.get('/join', isNotLoggedIn, renderJoin); // 라우터에서 컨트롤러 호출
 
 module.exports = router;

--- a/views/login.html
+++ b/views/login.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+
+{% block content %}
+  <h1>로그인</h1>
+  <form action="/user/login" method="post">
+    <div>
+      <label for="email">이메일:</label>
+      <input type="email" id="email" name="email" placeholder="이메일을 입력하세요" required>
+    </div>
+    <div>
+      <label for="password">비밀번호:</label>
+      <input type="password" id="password" name="password" placeholder="비밀번호를 입력하세요" required>
+    </div>
+    <div>
+      <button type="submit">로그인</button>
+    </div>
+  </form>
+
+  {% if loginError %}
+    <p style="color: red;">{{ loginError }}</p>
+  {% endif %}
+
+  <p>계정이 없으신가요? <a href="/user/join">회원가입</a></p>
+
+{% endblock %}

--- a/views/main.html
+++ b/views/main.html
@@ -2,4 +2,19 @@
 
 {% block content %}
   <h1>메인 홈페이지</h1>
+
+  <!-- 로그인 상태 확인 -->
+  {% if user %} 
+    <p>환영합니다, {{ user.nickname }}님!</p>
+    <form action="/user/logout" method="post">
+      <button type="submit">로그아웃</button>
+    </form>
+  {% else %}
+    <a href="/user/login">
+      <button>로그인</button>
+    </a>
+    <a href="/user/join">
+      <button>회원가입</button>
+    </a>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## 연관된 이슈
> #1 

## 작업 내용
> passport 모듈을 이용해 이메일 로그인과 로그아웃 구현
- controllers/auth.js: passport.authenticate / req.login 추가(promise 래핑+req.session.save로 세션 저장 명시)

- middlewares/index.js: 전역에서 쓸 로그인 관련 미들웨어 추가

- passport/index.js: passport 로그인에 필요한serializeUser(user.id만 세션에 저장), deserializeUser(세션에 저장된 id로 user 찾아 req.user에 할당) 추가

- passport/localStrategy.js: 이메일 활용해 사용자 인증을 위한 LocalStrategy 추가

- routes/auth.js: 회원가입, 로그인, 로그아웃 라우터 추가

- views/login,main.html: 로그인 화면 추가, 메인 화면 수정
### 스크린샷 (선택)

## 이슈 링크
> [node-express-practice #1 ](https://github.com/miso1105/node-express-practice/issues/1) 
